### PR TITLE
fix: move links to qualcomm-qrb-ros

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Read online documents
 
-QRB ROS Documents: [quic-qrb-ros.github.io](https://quic-qrb-ros.github.io)
+QRB ROS Documents: [qualcomm-qrb-ros.github.io](https://qualcomm-qrb-ros.github.io)
 
 ## Build documents
 

--- a/source/getting_started/docker_setup.rst
+++ b/source/getting_started/docker_setup.rst
@@ -7,7 +7,7 @@ This section will introduce the setup of QRB ROS Docker.
 Introdution
 -----------
 
-QRB ROS Docker is a docker application for `QRB ROS <https://github.com/quic-qrb-ros>`__, which provides a **fast** and **easy** way for developer to experience QRB ROS applications on QCOM Linux Yocto BSP releases.
+QRB ROS Docker is a docker application for `QRB ROS <https://github.com/qualcomm-qrb-ros>`__, which provides a **fast** and **easy** way for developer to experience QRB ROS applications on QCOM Linux Yocto BSP releases.
 
 QRB ROS Docker provides the ROS2 environment based on Ubuntu, here comes the way to run it.
 
@@ -21,7 +21,7 @@ Build QRB ROS Docker
 .. code:: bash
 
   mkdir -p /home/qrb_ros_ws/src && \
-  git clone https://github.com/quic-qrb-ros/qrb_ros_docker
+  git clone https://github.com/qualcomm-qrb-ros/qrb_ros_docker
 
 2. build the QRB ROS Docker
 
@@ -49,40 +49,40 @@ QRB ROS Docker now support **12** QRB ROS Packages, supported list is as below:
     * - Packages Name
       - Description
 
-    * - `qrb_ros_benchmark <https://github.com/quic-qrb-ros/qrb_ros_benchmark>`_
+    * - `qrb_ros_benchmark <https://github.com/qualcomm-qrb-ros/qrb_ros_benchmark>`_
       - Qualcomm Robotics platform Benchmark Tools.
 
-    * - `qrb_ros_nn_inference <https://github.com/quic-qrb-ros/qrb_ros_nn_inference>`_
+    * - `qrb_ros_nn_inference <https://github.com/qualcomm-qrb-ros/qrb_ros_nn_inference>`_
       - Qualcomm Robotics NatureNetwork Inference ROS Node.
 
-    * - `qrb_ros_transport <https://github.com/quic-qrb-ros/qrb_ros_transport>`_
+    * - `qrb_ros_transport <https://github.com/qualcomm-qrb-ros/qrb_ros_transport>`_
       - Zero Copy ROS Transport for Qualcomm platforms.
 
-    * - `qrb_ros_system_monitor <https://github.com/quic-qrb-ros/qrb_ros_system_monitor>`_
+    * - `qrb_ros_system_monitor <https://github.com/qualcomm-qrb-ros/qrb_ros_system_monitor>`_
       - QRB ROS System Monitor is a ROS package to access and publish system informations.
 
-    * - `qrb_ros_imu <https://github.com/quic-qrb-ros/qrb_ros_imu>`_
+    * - `qrb_ros_imu <https://github.com/qualcomm-qrb-ros/qrb_ros_imu>`_
       - Qualcomm Robotics platform IMU sensor ROS node.
 
-    * - `qrb_ros_interfaces <https://github.com/quic-qrb-ros/qrb_ros_interfaces>`_
+    * - `qrb_ros_interfaces <https://github.com/qualcomm-qrb-ros/qrb_ros_interfaces>`_
       - qrb_ros_interfaces is a ros2 package contains the custom qrb ros messages.
 
-    * - `qrb_ros_robot_base <https://github.com/quic-qrb-ros/qrb_ros_robot_base>`_
+    * - `qrb_ros_robot_base <https://github.com/qualcomm-qrb-ros/qrb_ros_robot_base>`_
       - Qualcomm Robotics platform Robot Base ROS Node.
 
-    * - `qrb_ros_audio_service <https://github.qualcomm.com/QUIC-QRB-ROS/qrb_ros_audio_service>`_
+    * - `qrb_ros_audio_service <https://github.com/qualcomm-qrb-ros/qrb_ros_audio_service>`_
       - Qualcomm Robotics Audio Service.
 
-    * - `qrb_ros_manipulator <https://github.com/quic-qrb-ros/qrb_ros_manipulator>`_
+    * - `qrb_ros_manipulator <https://github.com/qualcomm-qrb-ros/qrb_ros_manipulator>`_
       - Qualcomm Robotics manipulator ROS node.
 
-    * - `qrb_ros_yolo_processor <https://github.com/quic-qrb-ros/qrb_ros_yolo_processor>`_
+    * - `qrb_ros_yolo_processor <https://github.com/qualcomm-qrb-ros/qrb_ros_yolo_processor>`_
       - qrb_ros_yolo_processor provides ros nodes to execute pre/post-process for Yolo model.
 
-    * - `qrb_ros_amr_service <https://github.com/quic-qrb-ros/qrb_ros_amr_service>`_
+    * - `qrb_ros_amr_service <https://github.com/qualcomm-qrb-ros/qrb_ros_amr_service>`_
       - qrb_ros_amr_service is a package to manage the AMR behavior, such as navigation, mapping, return charging station.
 
-    * - `qrb_ros_color_space_convert <https://github.com/quic-qrb-ros/qrb_ros_color_space_convert>`_
+    * - `qrb_ros_color_space_convert <https://github.com/qualcomm-qrb-ros/qrb_ros_color_space_convert>`_
       - Qualcomm Robotics platform Color space conversion ROS node.
 
 

--- a/source/getting_started/first_example.rst
+++ b/source/getting_started/first_example.rst
@@ -29,10 +29,10 @@ Download Code
 
 .. code-block:: bash
 
-    git clone https://github.com/quic-qrb-ros/lib_mem_dmabuf.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_transport.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_camera.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_colorspace_convert.git
+    git clone https://github.com/qualcomm-qrb-ros/lib_mem_dmabuf.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_transport.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_camera.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_colorspace_convert.git
 
 Build
 ^^^^^

--- a/source/packages/libqrc/index.rst
+++ b/source/packages/libqrc/index.rst
@@ -45,7 +45,7 @@ Currently, we only support use QCLINUX to build
     
 .. code:: bash
 
-    git clone https://github.com/quic-qrb-ros/libqrc.git
+    git clone https://github.com/qualcomm-qrb-ros/libqrc.git
 
 4. Build this project
 

--- a/source/packages/package_list.rst
+++ b/source/packages/package_list.rst
@@ -6,38 +6,38 @@
       - Description
 
     * - :doc:`IMU </packages/qrb_ros_imu/index>`
-      - `qrb_ros_imu <https://github.com/quic-qrb-ros/qrb_ros_imu>`_
+      - `qrb_ros_imu <https://github.com/qualcomm-qrb-ros/qrb_ros_imu>`_
       - Qualcomm Robotics platform IMU sensor ROS node.
     * - :doc:`Camera </packages/qrb_ros_camera/index>`
-      - `qrb_ros_camera <https://github.com/quic-qrb-ros/qrb_ros_camera>`_
+      - `qrb_ros_camera <https://github.com/qualcomm-qrb-ros/qrb_ros_camera>`_
       - Qualcomm Robotics platform Camera ROS node.
     * - :doc:`Transport </packages/qrb_ros_transport/index>`
-      - `qrb_ros_transport <https://github.com/quic-qrb-ros/qrb_ros_transport>`_
+      - `qrb_ros_transport <https://github.com/qualcomm-qrb-ros/qrb_ros_transport>`_
       - Zero Copy ROS Transport for Qualcomm platforms.
     * - :doc:`Image Resize </packages/qrb_ros_image_resize/index>`
-      - `qrb_ros_image_resize <https://github.com/quic-qrb-ros/qrb_ros_image_resize>`_
+      - `qrb_ros_image_resize <https://github.com/qualcomm-qrb-ros/qrb_ros_image_resize>`_
       - Qualcomm Robotics platform Image Resize ROS node.
     * - :doc:`ColorSpace Convert </packages/qrb_ros_colorspace_convert/index>`
-      - `qrb_ros_color_space_convert <https://github.com/quic-qrb-ros/qrb_ros_color_space_convert>`_
+      - `qrb_ros_color_space_convert <https://github.com/qualcomm-qrb-ros/qrb_ros_color_space_convert>`_
       - Qualcomm Robotics platform Color space conversion ROS node.
     * - :doc:`Benchmark Tools</packages/qrb_ros_benchmark/index>`
-      - `qrb_ros_benchmark <https://github.com/quic-qrb-ros/qrb_ros_benchmark>`_
+      - `qrb_ros_benchmark <https://github.com/qualcomm-qrb-ros/qrb_ros_benchmark>`_
       - Qualcomm Robotics platform Benchmark Tools.
     * - :doc:`NN Inference </packages/qrb_ros_nn_inference/index>`
-      - `qrb_ros_nn_inference <https://github.com/quic-qrb-ros/qrb_ros_nn_inference>`_
+      - `qrb_ros_nn_inference <https://github.com/qualcomm-qrb-ros/qrb_ros_nn_inference>`_
       - Qualcomm Robotics NatureNetwork Inference ROS Node.
     * - :doc:`libqrc </packages/libqrc/index>`
-      - `libqrc <https://github.com/quic-qrb-ros/libqrc>`_
+      - `libqrc <https://github.com/qualcomm-qrb-ros/libqrc>`_
       - Qualcomm Robotics Communication protocol.
     * - :doc:`Audio Common </packages/qrb_ros_audio_common/index>`
-      - `qrb_ros_audio_common <https://github.com/quic-qrb-ros/qrb_ros_audio_common>`_
+      - `qrb_ros_audio_common <https://github.com/qualcomm-qrb-ros/qrb_ros_audio_common>`_
       - Qualcomm Robotics Audio Common.
     * - :doc:`robot base </packages/qrb_ros_robot_base/index>`
-      - `qrb_ros_robot_base <https://github.com/quic-qrb-ros/qrb_ros_robot_base>`_
+      - `qrb_ros_robot_base <https://github.com/qualcomm-qrb-ros/qrb_ros_robot_base>`_
       - Qualcomm Robotics platform Robot Base ROS Node.
     * - :doc:`System Monitor </packages/qrb_ros_system_monitor/index>`
-      - `qrb_ros_system_monitor <https://github.com/quic-qrb-ros/qrb_ros_system_monitor>`_
+      - `qrb_ros_system_monitor <https://github.com/qualcomm-qrb-ros/qrb_ros_system_monitor>`_
       - Qualcomm Robotics System Monitor ROS node.
     * - :doc:`Battery </packages/qrb_ros_battery/index>`
-      - `qrb_ros_battery <https://github.com/quic-qrb-ros/qrb_ros_battery>`_
+      - `qrb_ros_battery <https://github.com/qualcomm-qrb-ros/qrb_ros_battery>`_
       - Qualcomm Robotics platform Battery ROS node.

--- a/source/packages/qrb_ros_audio_common/index.rst
+++ b/source/packages/qrb_ros_audio_common/index.rst
@@ -26,8 +26,8 @@ Currently, we only support use QCLINUX to build
 
 .. code:: bash
 
-    git clone https://github.com/quic-qrb-ros/qrb_ros_audio_common.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_interfaces.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_audio_common.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_interfaces.git
 
 4. Build this project
 

--- a/source/packages/qrb_ros_battery/index.rst
+++ b/source/packages/qrb_ros_battery/index.rst
@@ -30,7 +30,7 @@ QuickStart
          .. code:: bash
 
                 cd ${QRB_ROS_WS}/src
-                git clone https://github.com/quic-qrb-ros/qrb_ros_battery.git
+                git clone https://github.com/qualcomm-qrb-ros/qrb_ros_battery.git
 
       3. Build packages
 
@@ -58,7 +58,7 @@ QuickStart
                 mkdir -p <qirp_decompressed_workspace>/qirp-sdk/ros_ws
                 cd <qirp_decompressed_workspace>/qirp-sdk/ros_ws
 
-                git clone https://github.com/quic-qrb-ros/qrb_ros_battery.git
+                git clone https://github.com/qualcomm-qrb-ros/qrb_ros_battery.git
 
       7. Build source code with QCLINUX SDK
 

--- a/source/packages/qrb_ros_benchmark/index.rst
+++ b/source/packages/qrb_ros_benchmark/index.rst
@@ -5,11 +5,11 @@ QRB ROS Benchmark
 Overview
 --------
 
-`QRB ROS Benchmark <https://github.com/quic-qrb-ros/qrb_ros_benchmark>`__ is a ros package
+`QRB ROS Benchmark <https://github.com/qualcomm-qrb-ros/qrb_ros_benchmark>`__ is a ros package
 that extends the functionality of open source ``ros2_benchmark`` package.
 
-QRB ROS Benchmark supports testing the performance of ROS nodes are accelerated by `dmabuf_transport <https://github.com/quic-qrb-ros/qrb_ros_transport>`__ and
-`qrb_ros_transport <https://github.com/quic-qrb-ros/dmabuf_transport>`__ function.
+QRB ROS Benchmark supports testing the performance of ROS nodes are accelerated by `dmabuf_transport <https://github.com/qualcomm-qrb-ros/qrb_ros_transport>`__ and
+`qrb_ros_transport <https://github.com/qualcomm-qrb-ros/dmabuf_transport>`__ function.
 dmabuf_transport and qrb_ros_transport provides type adaption and intra process communication to optimize message formats and dramatically accelerate
 communication between participating nodes.
 
@@ -26,13 +26,13 @@ Currently, we only support use QCLINUX to build
     
 .. code:: bash
 
-    git clone https://github.com/quic-qrb-ros/lib_mem_dmabuf.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_imu.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_transport.git
-    git clone https://github.com/quic-qrb-ros/dmabuf_transport.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_tensor_list_msgs.git
+    git clone https://github.com/qualcomm-qrb-ros/lib_mem_dmabuf.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_imu.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_transport.git
+    git clone https://github.com/qualcomm-qrb-ros/dmabuf_transport.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_tensor_list_msgs.git
     git clone https://github.com/NVIDIA-ISAAC-ROS/ros2_benchmark.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_benchmark.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_benchmark.git
 
 4. Add dependencies in ``ros2_benhcmark/ros2_benchmark/CMakeLists.txt`` file
 
@@ -73,7 +73,7 @@ Currently, we only support use QCLINUX to build
 Run
 ---
 
-QRB ROS Benchmark supports running it directly from the command with test script, taking the `qrb_ros_imu <https://github.com/quic-qrb-ros/qrb_ros_imu>`__ becnhamk test as an example.
+QRB ROS Benchmark supports running it directly from the command with test script, taking the `qrb_ros_imu <https://github.com/qualcomm-qrb-ros/qrb_ros_imu>`__ becnhamk test as an example.
 
 1. Source this file to set up the environment on your device:
 
@@ -85,7 +85,7 @@ QRB ROS Benchmark supports running it directly from the command with test script
     (ssh) export ROS_DOMAIN_ID=xx
     (ssh) source /usr/bin/ros_setup.bash
 
-2. Use this command to run this package with test script `qrb_ros_imu_benchmark.py <https://github.com/quic-qrb-ros/qrb_ros_benchmark/scripts/qrb_ros_imu_benchmark.py>`__ file.
+2. Use this command to run this package with test script `qrb_ros_imu_benchmark.py <https://github.com/qualcomm-qrb-ros/qrb_ros_benchmark/scripts/qrb_ros_imu_benchmark.py>`__ file.
 
 .. code:: bash
 
@@ -94,7 +94,7 @@ QRB ROS Benchmark supports running it directly from the command with test script
 3. After the benchmark test is completed, the performance measurement results will be displayed on the terminal.
 And will generate a json file containing the test results and metadata (such as system information, benchmark configuration). the result json file path: /tmp/xxx.json.
 
-The benchmark test result example: `qrb_ros_imu_qcm6490.json <https://github.com/quic-qrb-ros/qrb_ros_benchmark/results/qrb_ros_imu_qcm6490.json>`__.
+The benchmark test result example: `qrb_ros_imu_qcm6490.json <https://github.com/qualcomm-qrb-ros/qrb_ros_benchmark/results/qrb_ros_imu_qcm6490.json>`__.
 
 .. code:: bash
 
@@ -124,7 +124,7 @@ The benchmark test result example: `qrb_ros_imu_qcm6490.json <https://github.com
     "ResourceMetrics.STDDEV_OVERALL_CPU_UTILIZATION": 4.361769437087449,
 
 
-4. How to customize a test scripts, the test script example: `qrb_ros_imu_benchmark.py <https://github.com/quic-qrb-ros/qrb_ros_benchmark/scripts/qrb_ros_imu_benchmark.py>`__.
+4. How to customize a test scripts, the test script example: `qrb_ros_imu_benchmark.py <https://github.com/qualcomm-qrb-ros/qrb_ros_benchmark/scripts/qrb_ros_imu_benchmark.py>`__.
 
 Config ``qrb_ros::imu::ImuComponent`` and ``qrb_ros::benchmark::QrbMonitorNode`` plugins.
 set msg type on QrbMonitorNode plugin by ``monitor_data_format``, and remappings topic name to create pipeline:

--- a/source/packages/qrb_ros_benchmark/qrb_ros_benchmark.rst
+++ b/source/packages/qrb_ros_benchmark/qrb_ros_benchmark.rst
@@ -13,19 +13,19 @@ The following table lists current supported types:
     * - Msg Type
       - Description
 
-    * - `qrb_ros::transport::type::Image <https://github.com/quic-qrb-ros/qrb_ros_transport>`__
+    * - `qrb_ros::transport::type::Image <https://github.com/qualcomm-qrb-ros/qrb_ros_transport>`__
       - `Zero copy with qrb_ros_transport`
-    * - `qrb_ros::transport::type::Imu <https://github.com/quic-qrb-ros/qrb_ros_transport>`__
+    * - `qrb_ros::transport::type::Imu <https://github.com/qualcomm-qrb-ros/qrb_ros_transport>`__
       - `Zero copy with qrb_ros_transport`
-    * - `dmabuf_transport::type::Image <https://github.com/quic-qrb-ros/dmabuf_transport>`__
+    * - `dmabuf_transport::type::Image <https://github.com/qualcomm-qrb-ros/dmabuf_transport>`__
       - `Zero copy with dmabuf_transport`
-    * - `dmabuf_transport::type::PointCloud2 <https://github.com/quic-qrb-ros/dmabuf_transport>`__
+    * - `dmabuf_transport::type::PointCloud2 <https://github.com/qualcomm-qrb-ros/dmabuf_transport>`__
       - `Zero copy with dmabuf_transport`
     * - `sensor_msgs::msg::Image <https://github.com/ros2/common_interfaces/blob/rolling/sensor_msgs/msg/Imu.msg>`__
       - `Support intra-process communication`
     * - `sensor_msgs::msg::CompressedImage <https://github.com/ros2/common_interfaces/blob/rolling/sensor_msgs/msg/CompressedImage.msg>`__
       - `Support intra-process communication`
-    * - `qrb_ros_tensor_list_msgs::msg::TensorList <https://github.com/quic-qrb-ros/qrb_ros_tensor_list_msgs/blob/main/msg/TensorList.msg>`__
+    * - `qrb_ros_tensor_list_msgs::msg::TensorList <https://github.com/qualcomm-qrb-ros/qrb_ros_tensor_list_msgs/blob/main/msg/TensorList.msg>`__
       - `Support intra-process communication`
 
 .. |package_name| replace:: ``qrb_ros_benchnark``

--- a/source/packages/qrb_ros_camera/index.rst
+++ b/source/packages/qrb_ros_camera/index.rst
@@ -29,9 +29,9 @@ Currently, we only support use QCLINUX to build
     
 .. code:: bash
 
-    git clone https://github.com/quic-qrb-ros/lib_mem_dmabuf.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_transport.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_camera.git
+    git clone https://github.com/qualcomm-qrb-ros/lib_mem_dmabuf.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_transport.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_camera.git
 
 4. Build this project
 

--- a/source/packages/qrb_ros_colorspace_convert/index.rst
+++ b/source/packages/qrb_ros_colorspace_convert/index.rst
@@ -36,9 +36,9 @@ Currently, we only support use QCLINUX to build
     
 .. code:: bash
 
-    git clone https://github.com/quic-qrb-ros/lib_mem_dmabuf.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_transport.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_colorspace_convert.git
+    git clone https://github.com/qualcomm-qrb-ros/lib_mem_dmabuf.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_transport.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_colorspace_convert.git
 
 4. Build this project
 

--- a/source/packages/qrb_ros_image_resize/index.rst
+++ b/source/packages/qrb_ros_image_resize/index.rst
@@ -49,9 +49,9 @@ Currently, we only support NV12 color space format downscale that based on Qualc
     
 .. code:: bash
 
-    git clone https://github.com/quic-qrb-ros/lib_mem_dmabuf.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_transport.git
-    git clone https://github.com/quic-qrb-ros/qrb_ros_image_resize.git
+    git clone https://github.com/qualcomm-qrb-ros/lib_mem_dmabuf.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_transport.git
+    git clone https://github.com/qualcomm-qrb-ros/qrb_ros_image_resize.git
 
 4. Build this project
 

--- a/source/packages/qrb_ros_imu/index.rst
+++ b/source/packages/qrb_ros_imu/index.rst
@@ -34,9 +34,9 @@ QuickStart
          .. code:: bash
 
                 cd ${QRB_ROS_WS}/src
-                git clone https://github.com/quic-qrb-ros/lib_mem_dmabuf.git
-                git clone https://github.com/quic-qrb-ros/qrb_ros_imu.git
-                git clone https://github.com/quic-qrb-ros/qrb_ros_transport.git
+                git clone https://github.com/qualcomm-qrb-ros/lib_mem_dmabuf.git
+                git clone https://github.com/qualcomm-qrb-ros/qrb_ros_imu.git
+                git clone https://github.com/qualcomm-qrb-ros/qrb_ros_transport.git
 
       3. Build packages
 
@@ -64,7 +64,7 @@ QuickStart
                 mkdir -p <qirp_decompressed_workspace>/qirp-sdk/ros_ws
                 cd <qirp_decompressed_workspace>/qirp-sdk/ros_ws
 
-                git clone https://github.com/quic-qrb-ros/qrb_ros_imu.git
+                git clone https://github.com/qualcomm-qrb-ros/qrb_ros_imu.git
 
       3. Build source code with QCLINUX SDK
 

--- a/source/packages/qrb_ros_nn_inference/index.rst
+++ b/source/packages/qrb_ros_nn_inference/index.rst
@@ -14,7 +14,7 @@ here comes the usage scenario of qrb_ros_nn_inference:
   :align: left
   :alt: aha? why no image? try reflash your website.
 
-.. note:: TensorList is a custom ROS2 message type, more detail in `qrb_ros_tensor_list_msgs <https://github.com/quic-qrb-ros/qrb_ros_tensor_list_msgs>`__.
+.. note:: TensorList is a custom ROS2 message type, more detail in `qrb_ros_tensor_list_msgs <https://github.com/qualcomm-qrb-ros/qrb_ros_tensor_list_msgs>`__.
 
 qrb_ros_nn_inference is only for executing AI model inference, user should prepare a pre-process node and post-process node.
 pre-process node is for publishing the input data for model inference.
@@ -59,8 +59,8 @@ Construct ROS pipeline
   .. code:: bash
 
       cd <qirp_decompressed_workspace>/qirp-sdk/ros_ws && \
-      git clone https://github.com/quic-qrb-ros/qrb_ros_tensor_list_msgs.git && \
-      git clone https://github.com/quic-qrb-ros/qrb_ros_nn_inference.git
+      git clone https://github.com/qualcomm-qrb-ros/qrb_ros_tensor_list_msgs.git && \
+      git clone https://github.com/qualcomm-qrb-ros/qrb_ros_nn_inference.git
 
 3. Dynamically add inference node into the ros2 component container in your launch file
 

--- a/source/packages/qrb_ros_robot_base/index.rst
+++ b/source/packages/qrb_ros_robot_base/index.rst
@@ -5,7 +5,7 @@ QRB ROS Robot Base
 Overview
 --------
 QRB ROS Robot Base control package provide ROS interfaces  to control AMR robot base.
-It will init robot base, sync time with MCB, provide ROS interfaces for control robot base, publish robot base state with ROS topics and provide test tools for robot base control. All the data between MCB and RBx side through `QRC protocol <https://github.com/quic-qrb-ros/libqrc>`__.
+It will init robot base, sync time with MCB, provide ROS interfaces for control robot base, publish robot base state with ROS topics and provide test tools for robot base control. All the data between MCB and RBx side through `QRC protocol <https://github.com/qualcomm-qrb-ros/libqrc>`__.
 
 Quickstart
 ----------
@@ -27,9 +27,9 @@ Currently, we only support build with QCLINUX SDK.
    .. code:: bash
 
       cd <qirp_decompressed_workspace>/qirp-sdk/ros_ws
-      git clone https://github.com/quic-qrb-ros/libqrc.git
-      git clone https://github.com/quic-qrb-ros/qrb_ros_robot_base.git
-      git clone https://github.com/QUIC-QRB-ROS/qrb_ros_interfaces.git
+      git clone https://github.com/qualcomm-qrb-ros/libqrc.git
+      git clone https://github.com/qualcomm-qrb-ros/qrb_ros_robot_base.git
+      git clone https://github.com/qualcomm-qrb-ros/qrb_ros_interfaces.git
 
 4. Build projects
 

--- a/source/packages/qrb_ros_system_monitor/index.rst
+++ b/source/packages/qrb_ros_system_monitor/index.rst
@@ -5,7 +5,7 @@ QRB ROS System Monitor
 Overview
 --------
 
-`QRB ROS System Monitor <https://github.com/quic-qrb-ros/qrb_ros_system_monitor>`__ is a ROS package to publish system informations.
+`QRB ROS System Monitor <https://github.com/qualcomm-qrb-ros/qrb_ros_system_monitor>`__ is a ROS package to publish system informations.
 
 Main features:
 
@@ -42,7 +42,7 @@ Currently, we only support build with QCLINUX SDK.
 
    .. code:: bash
 
-      git clone https://github.com/quic-qrb-ros/qrb_ros_system_monitor.git
+      git clone https://github.com/qualcomm-qrb-ros/qrb_ros_system_monitor.git
 
 4. Build projects
 

--- a/source/packages/qrb_ros_system_monitor/qrb_ros_system_monitor.rst
+++ b/source/packages/qrb_ros_system_monitor/qrb_ros_system_monitor.rst
@@ -2,7 +2,7 @@
 |package_name|
 ==============
 
-`QRB ROS System Monitor <https://github.com/quic-qrb-ros/qrb_ros_system_monitor>`__ is a ROS package to publish system informations.
+`QRB ROS System Monitor <https://github.com/qualcomm-qrb-ros/qrb_ros_system_monitor>`__ is a ROS package to publish system informations.
 
 API
 ---

--- a/source/packages/qrb_ros_transport/dmabuf_transport.rst
+++ b/source/packages/qrb_ros_transport/dmabuf_transport.rst
@@ -8,7 +8,7 @@ Linux dma-buf file descriptor.
 Overview
 --------
 
-`Dmabuf Transport <https://github.com/quic-qrb-ros/dmabuf_transport>`__
+`Dmabuf Transport <https://github.com/qualcomm-qrb-ros/dmabuf_transport>`__
 provides a way to share data between different hardware accelerators and
 different ROS nodes with zero-copy.
 
@@ -54,7 +54,7 @@ QuickStart
       // publish message
       pub_->publish(std::move(msg));
 
--  Check `test <https://github.com/quic-qrb-ros/dmabuf_transport/tree/main/test>`__ directory to find more details.
+-  Check `test <https://github.com/qualcomm-qrb-ros/dmabuf_transport/tree/main/test>`__ directory to find more details.
 
 
 Supported Types
@@ -68,9 +68,9 @@ The following table lists current supported types:
     * - Dmabuf Transport Type
       - ROS Interface
 
-    * - `dmabuf_transport::type::Image <https://github.com/quic-qrb-ros/dmabuf_transport/tree/main/include/dmabuf_transport/type/image.hpp>`__
+    * - `dmabuf_transport::type::Image <https://github.com/qualcomm-qrb-ros/dmabuf_transport/tree/main/include/dmabuf_transport/type/image.hpp>`__
       - `sensor_msgs::msg::Image <https://github.com/ros2/common_interfaces/blob/rolling/sensor_msgs/msg/Image.msg>`__
-    * - `dmabuf_transport::type::PointCloud2 <https://github.com/quic-qrb-ros/dmabuf_transport/tree/main/include/dmabuf_transport/type/point_cloud2.hpp>`__
+    * - `dmabuf_transport::type::PointCloud2 <https://github.com/qualcomm-qrb-ros/dmabuf_transport/tree/main/include/dmabuf_transport/type/point_cloud2.hpp>`__
       - `sensor_msgs::msg::PointCloud2 <https://github.com/ros2/common_interfaces/blob/rolling/sensor_msgs/msg/PointCloud2.msg>`__
 
 

--- a/source/packages/qrb_ros_transport/index.rst
+++ b/source/packages/qrb_ros_transport/index.rst
@@ -6,7 +6,7 @@ Overview
 --------
 
 `QRB ROS
-Transport <https://github.com/quic-qrb-ros/qrb_ros_transport>`__ is
+Transport <https://github.com/qualcomm-qrb-ros/qrb_ros_transport>`__ is
 designed for hardware-acceleration friendly transporting of messages on
 Qualcomm robotics platforms. It uses type adaption to make message data
 zero-copy between different ROS nodes, and different hardwares. It
@@ -19,7 +19,7 @@ directly to the user requested type, and/or using that type in
 intra-process communication without ever converting it.
 
 qrb_ros_transport is based on
-`lib_mem_dmabuf <https://github.com/quic-qrb-ros/lib_mem_dmabuf>`__, it
+`lib_mem_dmabuf <https://github.com/qualcomm-qrb-ros/lib_mem_dmabuf>`__, it
 is open sourced and apply to all platforms based on Linux.
 
 dmabuf_transport is a zero-copy transport implementation for all platforms
@@ -53,9 +53,9 @@ Currently, we only support build with QCLINUX SDK.
    .. code:: bash
 
       cd <qirp_decompressed_workspace>/qirp-sdk/ros_ws
-      git clone https://github.com/quic-qrb-ros/lib_mem_dmabuf.git
-      git clone https://github.com/quic-qrb-ros/qrb_ros_imu.git
-      git clone https://github.com/quic-qrb-ros/qrb_ros_transport.git
+      git clone https://github.com/qualcomm-qrb-ros/lib_mem_dmabuf.git
+      git clone https://github.com/qualcomm-qrb-ros/qrb_ros_imu.git
+      git clone https://github.com/qualcomm-qrb-ros/qrb_ros_transport.git
 
 4. Build projects
 
@@ -94,7 +94,7 @@ Resources
    Linux kernel subsystem for sharing buffers for hardware (DMA) access
    across multiple device drivers and subsystems, and for synchronizing
    asynchronous hardware access
--  `lib_mem_dmabuf <https://github.com/quic-qrb-ros/lib_mem_dmabuf>`__:
+-  `lib_mem_dmabuf <https://github.com/qualcomm-qrb-ros/lib_mem_dmabuf>`__:
    Library for access and interact with Linux DMA heaps.
 
 Updates

--- a/source/packages/qrb_ros_transport/qrb_ros_transport.rst
+++ b/source/packages/qrb_ros_transport/qrb_ros_transport.rst
@@ -50,9 +50,9 @@ The following table lists current supported types:
     * - QRB ROS Transport Type
       - ROS Interface
 
-    * - `qrb_ros::transport::type::Image <https://github.com/quic-qrb-ros/qrb_ros_transport/tree/main//include/qrb_ros_transport/type/image.hpp>`__
+    * - `qrb_ros::transport::type::Image <https://github.com/qualcomm-qrb-ros/qrb_ros_transport/tree/main//include/qrb_ros_transport/type/image.hpp>`__
       - `sensor_msgs::msg::Image <https://github.com/ros2/common_interfaces/blob/rolling/sensor_msgs/msg/Image.msg>`__
-    * - `qrb_ros::transport::type::Imu <https://github.com/quic-qrb-ros/qrb_ros_transport/tree/main//include/qrb_ros_transport/type/imu.hpp>`__
+    * - `qrb_ros::transport::type::Imu <https://github.com/qualcomm-qrb-ros/qrb_ros_transport/tree/main//include/qrb_ros_transport/type/imu.hpp>`__
       - `sensor_msgs::msg::Imu <https://github.com/ros2/common_interfaces/blob/rolling/sensor_msgs/msg/Imu.msg>`__
 
 .. |package_name| replace:: ``qrb_ros_transport``


### PR DESCRIPTION
fix: move links from quic-qrb-ros to qualcomm-qrb-ros